### PR TITLE
Added installation directions for displaying line endings in status bar

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,12 @@ Allows to:
 
 Download or clone the contents of this repository to a folder named exactly as the package name into the Packages/ folder of ST.
 
+To display the line endings in the status bar, add the following to your ST3 User Preferences (Preferences > Settings - User)
+```
+{
+    "show_line_endings": true
+}
+```
 # Todo
 
 Show mixed line endings.


### PR DESCRIPTION
Hey Tito - Great ST3 plugin!

Here's just a quick documentation change to save people the googling I had to do after installation.

I could not figure out how to actually get the line endings displayed in the status bar. It was not obvious to me after reading the readme installation directions on how to do this. And I had no idea the setting was actually a ST3 User setting as opposed to a LineEndings package-specific setting.

Thanks to @fyears for finding the solution and posting it in issues.

Thanks again!
Chris
